### PR TITLE
feat: implementa logout com revogacao de refresh token

### DIFF
--- a/src/modules/auth/sessao/dto/login.types.ts
+++ b/src/modules/auth/sessao/dto/login.types.ts
@@ -1,11 +1,16 @@
 import type { z } from "zod";
 
-import type { schemaLogin, schemaRefreshToken } from "@/modules/auth/sessao/sessao.schemas";
+import type {
+  schemaLogin,
+  schemaLogout,
+  schemaRefreshToken,
+} from "@/modules/auth/sessao/sessao.schemas";
 import type { Papel } from "@/shared/constants/papeis";
 import type { Status } from "@/shared/constants/status";
 
 export type LoginDto = z.infer<typeof schemaLogin>;
 export type RefreshTokenDto = z.infer<typeof schemaRefreshToken>;
+export type LogoutDto = z.infer<typeof schemaLogout>;
 
 export type UsuarioSessaoDto = {
   id: string;

--- a/src/modules/auth/sessao/sessao.controller.ts
+++ b/src/modules/auth/sessao/sessao.controller.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 
 import type {
   LoginDto,
+  LogoutDto,
   RefreshTokenDto,
   RespostaLoginDto,
   RespostaRenovarSessaoDto,
@@ -45,6 +46,28 @@ export class SessaoController {
         mensagem: MENSAGENS.sessaoRenovada,
         dados,
       });
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  logout = async (
+    request: Request<unknown, unknown, LogoutDto>,
+    response: Response<void>,
+    next: NextFunction,
+  ) => {
+    try {
+      if (!request.usuario) {
+        throw new ErroAplicacao({
+          codigoStatus: 401,
+          codigo: CodigoDeErro.TOKEN_INVALIDO,
+          mensagem: MENSAGENS.tokenInvalido,
+        });
+      }
+
+      await this.sessaoService.logout(request.usuario.id, request.body);
+
+      return response.status(204).send();
     } catch (error) {
       return next(error);
     }

--- a/src/modules/auth/sessao/sessao.repository.ts
+++ b/src/modules/auth/sessao/sessao.repository.ts
@@ -255,4 +255,16 @@ export class SessaoRepository {
       return true;
     });
   }
+
+  async revogarRefreshToken(token: string, usuarioId: string): Promise<boolean> {
+    const tokensRevogados = await prisma.$executeRaw`
+      UPDATE refresh_tokens
+      SET "revogadoEm" = NOW()
+      WHERE token = ${token}
+        AND "usuarioId" = ${usuarioId}
+        AND "revogadoEm" IS NULL
+    `;
+
+    return tokensRevogados > 0;
+  }
 }

--- a/src/modules/auth/sessao/sessao.routes.ts
+++ b/src/modules/auth/sessao/sessao.routes.ts
@@ -2,7 +2,11 @@ import { Router } from "express";
 
 import { SessaoController } from "@/modules/auth/sessao/sessao.controller";
 import { SessaoRepository } from "@/modules/auth/sessao/sessao.repository";
-import { schemaLogin, schemaRefreshToken } from "@/modules/auth/sessao/sessao.schemas";
+import {
+  schemaLogin,
+  schemaLogout,
+  schemaRefreshToken,
+} from "@/modules/auth/sessao/sessao.schemas";
 import { SessaoService } from "@/modules/auth/sessao/sessao.service";
 import { middlewareAutenticacao } from "@/shared/middlewares/autenticacao.middleware";
 import { validarRequisicao } from "@/shared/middlewares/validacao.middleware";
@@ -20,5 +24,11 @@ sessaoRouter.post(
   sessaoController.renovarSessao,
 );
 sessaoRouter.get("/me", middlewareAutenticacao, sessaoController.obterUsuarioAutenticado);
+sessaoRouter.post(
+  "/logout",
+  middlewareAutenticacao,
+  validarRequisicao(schemaLogout),
+  sessaoController.logout,
+);
 
 export { sessaoRouter };

--- a/src/modules/auth/sessao/sessao.schemas.ts
+++ b/src/modules/auth/sessao/sessao.schemas.ts
@@ -13,3 +13,5 @@ export const schemaLogin = z.object({
 export const schemaRefreshToken = z.object({
   refreshToken: z.string().trim().min(1),
 });
+
+export const schemaLogout = schemaRefreshToken;

--- a/src/modules/auth/sessao/sessao.service.ts
+++ b/src/modules/auth/sessao/sessao.service.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import { jwtRefreshSecretKey } from "@/config/env";
 import type {
   LoginDto,
+  LogoutDto,
   RefreshTokenDto,
   RespostaLoginDto,
   RespostaRenovarSessaoDto,
@@ -200,5 +201,24 @@ export class SessaoService {
       accessToken,
       refreshToken,
     };
+  }
+
+  async logout(usuarioId: string, input: LogoutDto): Promise<void> {
+    const refreshToken = input.refreshToken.trim();
+    const refreshTokenSalvo = await this.sessaoRepository.buscarRefreshToken(refreshToken);
+
+    if (
+      !refreshTokenSalvo ||
+      refreshTokenSalvo.revogadoEm ||
+      refreshTokenSalvo.usuarioId !== usuarioId
+    ) {
+      throw criarErroTokenInvalido();
+    }
+
+    const tokenRevogado = await this.sessaoRepository.revogarRefreshToken(refreshToken, usuarioId);
+
+    if (!tokenRevogado) {
+      throw criarErroTokenInvalido();
+    }
   }
 }

--- a/tests/unit/auth/sessao/sessao.controller.test.ts
+++ b/tests/unit/auth/sessao/sessao.controller.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { SessaoController } from "@/modules/auth/sessao/sessao.controller";
 import type {
   LoginDto,
+  LogoutDto,
   RefreshTokenDto,
   RespostaLoginDto,
   RespostaRenovarSessaoDto,
@@ -134,6 +135,37 @@ describe("SessaoController", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("retorna 204 ao realizar logout", async () => {
+    const body: LogoutDto = {
+      refreshToken: "refresh-token",
+    };
+    const logout = jest.fn<SessaoService["logout"]>().mockResolvedValue(undefined);
+    const controller = new SessaoController({
+      logout,
+    } as unknown as SessaoService);
+    const request = {
+      body,
+      usuario: {
+        id: "usuario-id",
+        email: "joao@aluno.unb.br",
+        papel: PAPEIS.ALUNO,
+      },
+    } as Request<unknown, unknown, LogoutDto>;
+    const send = jest.fn();
+    const status = jest.fn(() => ({ send }));
+    const response = {
+      status,
+    } as unknown as Response<void>;
+    const next = jest.fn();
+
+    await controller.logout(request, response, next);
+
+    expect(logout).toHaveBeenCalledWith("usuario-id", body);
+    expect(status).toHaveBeenCalledWith(204);
+    expect(send).toHaveBeenCalledWith();
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("encaminha erro do service para o middleware de erro", async () => {
     const error = new Error("erro");
     const login = jest.fn<SessaoService["login"]>().mockRejectedValue(error);
@@ -165,6 +197,29 @@ describe("SessaoController", () => {
 
     await controller.renovarSessao(request, response, next);
 
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it("encaminha erro do service ao realizar logout", async () => {
+    const error = new Error("erro");
+    const logout = jest.fn<SessaoService["logout"]>().mockRejectedValue(error);
+    const controller = new SessaoController({
+      logout,
+    } as unknown as SessaoService);
+    const request = {
+      body: { refreshToken: "refresh-token" },
+      usuario: {
+        id: "usuario-id",
+        email: "joao@aluno.unb.br",
+        papel: PAPEIS.ALUNO,
+      },
+    } as Request<unknown, unknown, LogoutDto>;
+    const response = {} as Response<void>;
+    const next = jest.fn();
+
+    await controller.logout(request, response, next);
+
+    expect(logout).toHaveBeenCalledWith("usuario-id", { refreshToken: "refresh-token" });
     expect(next).toHaveBeenCalledWith(error);
   });
 
@@ -204,6 +259,29 @@ describe("SessaoController", () => {
     await controller.obterUsuarioAutenticado(request, response, next);
 
     expect(obterUsuarioAutenticado).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        codigoStatus: 401,
+        codigo: CodigoDeErro.TOKEN_INVALIDO,
+        message: MENSAGENS.tokenInvalido,
+      }),
+    );
+  });
+
+  it("encaminha erro quando logout e chamado sem usuario autenticado", async () => {
+    const logout = jest.fn<SessaoService["logout"]>();
+    const controller = new SessaoController({
+      logout,
+    } as unknown as SessaoService);
+    const request = {
+      body: { refreshToken: "refresh-token" },
+    } as Request<unknown, unknown, LogoutDto>;
+    const response = {} as Response<void>;
+    const next = jest.fn();
+
+    await controller.logout(request, response, next);
+
+    expect(logout).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(
       expect.objectContaining({
         codigoStatus: 401,

--- a/tests/unit/auth/sessao/sessao.repository.test.ts
+++ b/tests/unit/auth/sessao/sessao.repository.test.ts
@@ -218,4 +218,24 @@ describe("SessaoRepository", () => {
 
     expect(executeRawTransacao).toHaveBeenCalledTimes(1);
   });
+
+  it("revoga refresh token da sessao atual", async () => {
+    executeRawMock.mockResolvedValueOnce(1);
+    const repository = new SessaoRepository();
+
+    await expect(
+      repository.revogarRefreshToken("refresh-token", "usuario-id"),
+    ).resolves.toBe(true);
+
+    expect(executeRawMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retorna false quando nenhum refresh token foi revogado", async () => {
+    executeRawMock.mockResolvedValueOnce(0);
+    const repository = new SessaoRepository();
+
+    await expect(
+      repository.revogarRefreshToken("refresh-token", "usuario-id"),
+    ).resolves.toBe(false);
+  });
 });

--- a/tests/unit/auth/sessao/sessao.schemas.test.ts
+++ b/tests/unit/auth/sessao/sessao.schemas.test.ts
@@ -1,7 +1,11 @@
 import type { Request, Response } from "express";
 import type { ZodType } from "zod";
 
-import { schemaLogin, schemaRefreshToken } from "@/modules/auth/sessao/sessao.schemas";
+import {
+  schemaLogin,
+  schemaLogout,
+  schemaRefreshToken,
+} from "@/modules/auth/sessao/sessao.schemas";
 import { CodigoDeErro } from "@/shared/errors/codigos-de-erro";
 import { validarRequisicao } from "@/shared/middlewares/validacao.middleware";
 
@@ -69,5 +73,17 @@ describe("schemaRefreshToken", () => {
         codigo: CodigoDeErro.ERRO_DE_VALIDACAO,
       }),
     );
+  });
+});
+
+describe("schemaLogout", () => {
+  it("normaliza refresh token usado no logout", () => {
+    const resultado = schemaLogout.parse({
+      refreshToken: " refresh-token ",
+    });
+
+    expect(resultado).toEqual({
+      refreshToken: "refresh-token",
+    });
   });
 });

--- a/tests/unit/auth/sessao/sessao.service.test.ts
+++ b/tests/unit/auth/sessao/sessao.service.test.ts
@@ -57,6 +57,9 @@ function criarSessaoRepositoryMock(usuario: UsuarioSessao | null = criarUsuarioS
   const rotacionarRefreshToken = jest
     .fn<SessaoRepository["rotacionarRefreshToken"]>()
     .mockResolvedValue(true);
+  const revogarRefreshToken = jest
+    .fn<SessaoRepository["revogarRefreshToken"]>()
+    .mockResolvedValue(true);
 
   return {
     sessaoRepository: {
@@ -65,12 +68,14 @@ function criarSessaoRepositoryMock(usuario: UsuarioSessao | null = criarUsuarioS
       salvarRefreshToken,
       buscarRefreshToken,
       rotacionarRefreshToken,
+      revogarRefreshToken,
     } as unknown as SessaoRepository,
     buscarUsuarioPorEmail,
     buscarUsuarioPorId,
     salvarRefreshToken,
     buscarRefreshToken,
     rotacionarRefreshToken,
+    revogarRefreshToken,
   };
 }
 
@@ -211,6 +216,102 @@ describe("SessaoService", () => {
       resposta.refreshToken,
       expect.any(Date),
     );
+  });
+
+  it("realiza logout revogando refresh token da sessao atual", async () => {
+    const refreshToken = gerarRefreshToken(criarPayloadAutenticacao());
+    const { sessaoRepository, buscarRefreshToken, revogarRefreshToken } =
+      criarSessaoRepositoryMock();
+    buscarRefreshToken.mockResolvedValueOnce({
+      token: refreshToken,
+      usuarioId: "usuario-id",
+      expiraEm: new Date(Date.now() + 60 * 60 * 1000),
+      revogadoEm: null,
+    });
+    const service = new SessaoService(sessaoRepository);
+
+    await expect(
+      service.logout("usuario-id", { refreshToken: ` ${refreshToken} ` }),
+    ).resolves.toBeUndefined();
+
+    expect(buscarRefreshToken).toHaveBeenCalledWith(refreshToken);
+    expect(revogarRefreshToken).toHaveBeenCalledWith(refreshToken, "usuario-id");
+  });
+
+  it("retorna 401 ao fazer logout com refresh token nao encontrado", async () => {
+    const { sessaoRepository, buscarRefreshToken, revogarRefreshToken } =
+      criarSessaoRepositoryMock();
+    buscarRefreshToken.mockResolvedValueOnce(null);
+    const service = new SessaoService(sessaoRepository);
+
+    await expect(
+      service.logout("usuario-id", { refreshToken: "refresh-token-inexistente" }),
+    ).rejects.toMatchObject({
+      codigoStatus: 401,
+      codigo: CodigoDeErro.TOKEN_INVALIDO,
+      message: MENSAGENS.tokenInvalido,
+    });
+    expect(revogarRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("retorna 401 ao fazer logout com refresh token ja revogado", async () => {
+    const refreshToken = gerarRefreshToken(criarPayloadAutenticacao());
+    const { sessaoRepository, buscarRefreshToken, revogarRefreshToken } =
+      criarSessaoRepositoryMock();
+    buscarRefreshToken.mockResolvedValueOnce({
+      token: refreshToken,
+      usuarioId: "usuario-id",
+      expiraEm: new Date(Date.now() + 60 * 60 * 1000),
+      revogadoEm: new Date("2026-04-26T12:00:00.000Z"),
+    });
+    const service = new SessaoService(sessaoRepository);
+
+    await expect(service.logout("usuario-id", { refreshToken })).rejects.toMatchObject({
+      codigoStatus: 401,
+      codigo: CodigoDeErro.TOKEN_INVALIDO,
+      message: MENSAGENS.tokenInvalido,
+    });
+    expect(revogarRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("retorna 401 ao fazer logout com refresh token de outro usuario", async () => {
+    const refreshToken = gerarRefreshToken(criarPayloadAutenticacao());
+    const { sessaoRepository, buscarRefreshToken, revogarRefreshToken } =
+      criarSessaoRepositoryMock();
+    buscarRefreshToken.mockResolvedValueOnce({
+      token: refreshToken,
+      usuarioId: "outro-usuario-id",
+      expiraEm: new Date(Date.now() + 60 * 60 * 1000),
+      revogadoEm: null,
+    });
+    const service = new SessaoService(sessaoRepository);
+
+    await expect(service.logout("usuario-id", { refreshToken })).rejects.toMatchObject({
+      codigoStatus: 401,
+      codigo: CodigoDeErro.TOKEN_INVALIDO,
+      message: MENSAGENS.tokenInvalido,
+    });
+    expect(revogarRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("retorna 401 ao fazer logout quando token nao foi revogado por concorrencia", async () => {
+    const refreshToken = gerarRefreshToken(criarPayloadAutenticacao());
+    const { sessaoRepository, buscarRefreshToken, revogarRefreshToken } =
+      criarSessaoRepositoryMock();
+    buscarRefreshToken.mockResolvedValueOnce({
+      token: refreshToken,
+      usuarioId: "usuario-id",
+      expiraEm: new Date(Date.now() + 60 * 60 * 1000),
+      revogadoEm: null,
+    });
+    revogarRefreshToken.mockResolvedValueOnce(false);
+    const service = new SessaoService(sessaoRepository);
+
+    await expect(service.logout("usuario-id", { refreshToken })).rejects.toMatchObject({
+      codigoStatus: 401,
+      codigo: CodigoDeErro.TOKEN_INVALIDO,
+      message: MENSAGENS.tokenInvalido,
+    });
   });
 
   it("retorna 401 ao renovar sessao com refresh token expirado", async () => {


### PR DESCRIPTION
## Descrição

Implementa o logout de sessão no backend, permitindo que um usuário autenticado encerre a sessão atual com segurança por meio da revogação do refresh token enviado na requisição.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes #15
Relates to #11

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Evidências (se aplicável)

- Endpoint implementado: `POST /api/v1/auth/logout`
- Resposta esperada em caso de sucesso: `204 No Content`
<img width="1495" height="570" alt="image" src="https://github.com/user-attachments/assets/7b646341-29f2-448d-9c95-79a26cc7a2ca" />

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

O logout revoga apenas o refresh token enviado na requisição, encerrando a sessão atual/dispositivo atual. O access token não é invalidado imediatamente e continua válido até sua expiração natural, comportamento esperado para o modelo atual baseado em JWT stateless.

Foram adicionados testes unitários para controller, service, repository e schema.