### PR TITLE
feat: adiciona seed de usuário professor

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -43,6 +43,32 @@ async function main() {
     },
   });
 
+  const professorEmail = process.env.PROFESSOR_EMAIL ?? "professor@anatoquizup.com";
+  const professorPassword = process.env.PROFESSOR_PASSWORD ?? "professor123";
+
+  const senhaProfessorHash = await bcrypt.hash(professorPassword, 10);
+
+  await prisma.usuario.upsert({
+    where: { email: professorEmail },
+    update: {
+      nome: "Professor Seed",
+      senha: senhaProfessorHash,
+      perfil: PerfilUsuario.PROFESSOR,
+      status: StatusUsuario.ATIVO,
+      departamento: "Departamento de Anatomia",
+      siape: "0000001",
+    },
+    create: {
+      nome: "Professor Seed",
+      email: professorEmail,
+      senha: senhaProfessorHash,
+      perfil: PerfilUsuario.PROFESSOR,
+      status: StatusUsuario.ATIVO,
+      departamento: "Departamento de Anatomia",
+      siape: "0000001",
+    },
+  });
+
   console.log("Seed executado com sucesso.");
 }
 


### PR DESCRIPTION
## Descrição

Adiciona um usuário professor no seed do banco de dados para facilitar testes e validação das funcionalidades relacionadas ao perfil de professor.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes: #
Relates to: #

Commits relacionados:

- 9df3791

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [ ] Testes

## Evidências (se aplicável)

- Seed executado localmente com sucesso
- Usuário professor criado no banco

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [ ] PR está vinculado a uma issue (US ou Task)
- [ ] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

Uso de valores padrão para email e senha do professor via variáveis de ambiente, com fallback para ambiente local.