### PR TITLE
chore: executa seed ao iniciar container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 
 EXPOSE 3333
 
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/src/server.js"]
+CMD ["sh", "-c", "npx prisma migrate deploy && npx prisma db seed && node dist/src/server.js"]


### PR DESCRIPTION
## Descrição

Adiciona execução automática do seed ao iniciar o container Docker.  
Agora, além das migrations (`prisma migrate deploy`), o comando `prisma db seed` também é executado antes de subir a aplicação.

## Rastreabilidade

Issue(s) Relacionada(s):

Closes: #
Relates to: #

Commits relacionados:

- <hash-do-commit>

## Tipo de Mudança

- [ ] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [x] Refactor (melhoria interna)
- [ ] Documentação
- [ ] Testes

## Evidências (se aplicável)

- Logs de inicialização do container mostrando execução de:
  - `prisma migrate deploy`
  - `prisma db seed`

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [ ] PR está vinculado a uma issue (US ou Task)
- [ ] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

A seed agora é executada a cada inicialização do container.  
É importante garantir que o script de seed seja idempotente para evitar duplicação ou inconsistência de dados.