### PR TITLE
feat: adiciona modelagem de questões

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,12 +40,33 @@ enum NivelEducacional {
   OUTRO
 }
 
+enum TipoQuestao {
+  MULTIPLA_ESCOLHA
+  CERTO_ERRADO
+}
+
+// Representa a alternativa selecionada/correta.
+// Para MULTIPLA_ESCOLHA: A, B, C, D ou E.
+// Para CERTO_ERRADO: C = Certo e E = Errado.
+enum AlternativaQuestao {
+  A
+  B
+  C
+  D
+  E
+}
+
+enum StatusQuestao {
+  ATIVO
+  INATIVO
+}
+
 model Usuario {
-  id    String @id @default(cuid())
-  nome  String
+  id       String  @id @default(cuid())
+  nome     String
   nickname String? @unique
-  email String @unique
-  senha String
+  email    String  @unique
+  senha    String
 
   perfil PerfilUsuario
   status StatusUsuario @default(ATIVO)
@@ -70,6 +91,9 @@ model Usuario {
 
   refreshTokens          RefreshToken[]
   tokensRedefinicaoSenha TokenRedefinicaoSenha[]
+
+  questoesCriadas Questao[]          @relation("QuestoesCriadas")
+  resolucoes      ResolucaoQuestao[]
 
   criadoEm     DateTime  @default(now())
   atualizadoEm DateTime  @updatedAt
@@ -104,4 +128,86 @@ model TokenRedefinicaoSenha {
   usuario Usuario @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
 
   @@map("tokens_redefinicao_senha")
+}
+
+model Tema {
+  id   String @id @default(cuid())
+  nome String
+
+  questoes Questao[]
+
+  criadoEm     DateTime  @default(now())
+  atualizadoEm DateTime  @updatedAt
+  excluidoEm   DateTime?
+
+  @@map("temas")
+}
+
+model Questao {
+  id              String             @id @default(cuid())
+  enunciado       String
+  tipoQuestao     TipoQuestao
+  respostaCorreta AlternativaQuestao
+  saibaMais       String?
+  status          StatusQuestao      @default(ATIVO)
+  feitoPorIa      Boolean            @default(false)
+  urlImagem       String?
+
+  criadoPorId String
+  temaId      String
+
+  // Guarda o id da questão original quando esta questão for uma nova versão.
+  questaoOriginalId String?
+  // Permite acessar a questão original a partir desta versão.
+  questaoOriginal   Questao?  @relation("VersoesQuestao", fields: [questaoOriginalId], references: [id])
+  // Lista as versões criadas a partir desta questão.
+  versoes           Questao[] @relation("VersoesQuestao")
+
+  criadoPor Usuario @relation("QuestoesCriadas", fields: [criadoPorId], references: [id], onDelete: Restrict)
+  tema      Tema    @relation(fields: [temaId], references: [id], onDelete: Restrict)
+
+  alternativas QuestaoAlternativa?
+  resolucoes   ResolucaoQuestao[]
+
+  criadoEm     DateTime  @default(now())
+  atualizadoEm DateTime  @updatedAt
+  excluidoEm   DateTime?
+
+  @@map("questoes")
+}
+
+model QuestaoAlternativa {
+  id String @id @default(cuid())
+
+  alternativaA String
+  alternativaB String
+  alternativaC String
+  alternativaD String
+  alternativaE String
+
+  questaoId String  @unique
+  questao   Questao @relation(fields: [questaoId], references: [id], onDelete: Restrict)
+
+  criadoEm     DateTime  @default(now())
+  atualizadoEm DateTime  @updatedAt
+  excluidoEm   DateTime?
+
+  @@map("questoes_alternativas")
+}
+
+model ResolucaoQuestao {
+  id              String             @id @default(cuid())
+  respostaMarcada AlternativaQuestao
+
+  usuarioId String
+  questaoId String
+
+  usuario Usuario @relation(fields: [usuarioId], references: [id], onDelete: Restrict)
+  questao Questao @relation(fields: [questaoId], references: [id], onDelete: Restrict)
+
+  criadoEm     DateTime  @default(now())
+  atualizadoEm DateTime  @updatedAt
+  excluidoEm   DateTime?
+
+  @@map("resolucoes_questoes")
 }


### PR DESCRIPTION
## Descrição

Adiciona a modelagem de questões no banco de dados utilizando Prisma.

Foram incluídas as entidades:
- Questao
- Tema
- QuestaoAlternativa
- ResolucaoQuestao

Também foram criados enums para padronização:
- TipoQuestao
- StatusQuestao
- AlternativaQuestao

Inclui suporte a versionamento de questões, permitindo manter histórico consistente das respostas dos alunos mesmo após edições.

---

## Rastreabilidade

Issue(s) Relacionada(s):

Closes: #
Relates to: #

Commits relacionados:

- (deixe o GitLab/GitHub preencher automaticamente)

---

## Tipo de Mudança

- [x] Feature (nova funcionalidade)
- [ ] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [ ] Testes

---

## Evidências (se aplicável)

- Schema validado com:
  - `npx prisma validate`
- Estrutura modelada e versionada corretamente no banco

---

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [ ] PR está vinculado a uma issue (US ou Task)
- [ ] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

---

## Observações

- Para questões do tipo CERTO_ERRADO, a regra é:
  - C = Certo
  - E = Errado

- O controle de versionamento das questões foi implementado no schema, mas a lógica de criação de novas versões deve ser tratada na camada de serviço.