### PR TITLE
fix: nome no cadastro de aluno e professor nao aceita mais caracteres…

### DIFF
--- a/src/modules/auth/aluno/aluno.schemas.ts
+++ b/src/modules/auth/aluno/aluno.schemas.ts
@@ -9,10 +9,15 @@ import {
 } from "@/modules/auth/aluno/aluno.constants";
 
 const FORMATO_DATA_ISO = /^\d{4}-\d{2}-\d{2}$/;
+const FORMATO_NOME_COMPLETO = /^[A-Za-zÀ-ÖØ-öø-ÿ ]+$/;
 
 function textoObrigatorio(max: number) {
   return z.string().trim().min(1).max(max);
 }
+
+const schemaNomeCompleto = textoObrigatorio(120).regex(FORMATO_NOME_COMPLETO, {
+  message: "Nome completo deve conter apenas letras e espacos.",
+});
 
 function dataIsoValida(valor: string) {
   if (!FORMATO_DATA_ISO.test(valor)) {
@@ -54,7 +59,7 @@ export const schemaDisponibilidadeEmailAluno = z.object({
 
 export const schemaRegistrarAluno = z
   .object({
-    nome: textoObrigatorio(120),
+    nome: schemaNomeCompleto,
     nickname: schemaNicknameAluno,
     email: schemaEmailAluno,
     senha: z.string().min(8),

--- a/src/modules/auth/professor/professor.schemas.test.ts
+++ b/src/modules/auth/professor/professor.schemas.test.ts
@@ -33,6 +33,37 @@ describe("schemaRegistrarProfessor", () => {
     }
   });
 
+  test("aceita letras acentuadas e espacos no nome completo", () => {
+    const resultado = schemaRegistrarProfessor.safeParse({
+      ...dadosValidos,
+      nome: "Hílmer José",
+    });
+
+    expect(resultado.success).toBe(true);
+  });
+
+  test.each(["Hilmer Neri 123", "Hilmer@ Neri"])(
+    "rejeita nome completo com caracteres invalidos: %s",
+    (nome) => {
+      const resultado = schemaRegistrarProfessor.safeParse({
+        ...dadosValidos,
+        nome,
+      });
+
+      expect(resultado.success).toBe(false);
+      if (!resultado.success) {
+        expect(resultado.error.issues).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              path: ["nome"],
+              message: "Nome completo deve conter apenas letras e espacos.",
+            }),
+          ]),
+        );
+      }
+    },
+  );
+
   test("rejeita email fora do dominio UnB", () => {
     const resultado = schemaRegistrarProfessor.safeParse({
       ...dadosValidos,

--- a/src/modules/auth/professor/professor.schemas.ts
+++ b/src/modules/auth/professor/professor.schemas.ts
@@ -2,10 +2,15 @@ import { z } from "zod";
 
 const FORMATO_EMAIL_UNB = /^[^\s@]+@(?:[a-z0-9-]+\.)*unb\.br$/i;
 const FORMATO_SIAPE = /^\d{7}$/;
+const FORMATO_NOME_COMPLETO = /^[A-Za-zÀ-ÖØ-öø-ÿ ]+$/;
 
 function textoObrigatorio(max: number) {
   return z.string().trim().min(1).max(max);
 }
+
+const schemaNomeCompleto = textoObrigatorio(120).regex(FORMATO_NOME_COMPLETO, {
+  message: "Nome completo deve conter apenas letras e espacos.",
+});
 
 export const schemaEmailProfessor = z
   .string()
@@ -23,7 +28,7 @@ export const schemaSiapeProfessor = z.string().trim().regex(FORMATO_SIAPE, {
 
 export const schemaRegistrarProfessor = z
   .object({
-    nome: textoObrigatorio(120),
+    nome: schemaNomeCompleto,
     email: schemaEmailProfessor,
     siape: schemaSiapeProfessor,
     instituicao: z

--- a/tests/unit/auth/aluno/aluno.schemas.test.ts
+++ b/tests/unit/auth/aluno/aluno.schemas.test.ts
@@ -55,6 +55,15 @@ describe("schemaRegistrarAluno", () => {
     });
   });
 
+  it("aceita letras acentuadas e espacos no nome completo", () => {
+    const resultado = schemaRegistrarAluno.safeParse({
+      ...payloadValido,
+      nome: "João Álvares",
+    });
+
+    expect(resultado.success).toBe(true);
+  });
+
   it("rejeita email invalido na consulta de disponibilidade", () => {
     expect(() => schemaDisponibilidadeEmailAluno.parse({ email: "email-invalido" })).toThrow();
   });
@@ -87,6 +96,8 @@ describe("schemaRegistrarAluno", () => {
     ["nickname com simbolo", { nickname: "joao!" }],
     ["nickname comecando com numero", { nickname: "1joao" }],
     ["nome vazio", { nome: "   " }],
+    ["nome com numero", { nome: "Joao Silva 123" }],
+    ["nome com caractere especial", { nome: "Joao@ Silva" }],
     ["data de nascimento ausente", { dataNascimento: undefined }],
     ["data de nascimento invalida", { dataNascimento: "30/12/2003" }],
     ["nacionalidade ausente", { nacionalidade: undefined }],


### PR DESCRIPTION
## Descrição

Corrige a validação do campo **Nome Completo** nos cadastros de aluno e professor.

- Aceita letras, espaços e caracteres acentuados.
- Rejeita números e caracteres especiais.
- Exibe uma mensagem de validação adequada.
- Aplica a validação no frontend e no `Usuario-Service`.

## Rastreabilidade

Commits relacionados:

- 60f88b5

## Tipo de Mudança

- [ ] Feature (nova funcionalidade)
- [x] Bugfix (correção de erro)
- [ ] Refactor (melhoria interna)
- [ ] Documentação
- [x] Testes

## Checklist

- [x] Código segue o padrão de commits (Commitizen)
- [x] PR está vinculado a uma issue (US ou Task)
- [x] Testes foram adicionados/atualizados
- [x] Código revisado localmente
- [x] Não quebra funcionalidades existentes

## Observações

A validação foi implementada no frontend e no backend para impedir que a regra seja contornada por requisições diretas à API.